### PR TITLE
🐛 FIX: Image link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ The table should have the following properties:
 - `Date`: this is when the blog post appears as posted, it should be a date property
 - `Authors`: this is a list of Notion users that wrote the post, it should be a person property
 
-![Example Blog Posts Table](assets/table-view.png)
+![Example Blog Posts Table](./assets/table-view.png)
 
 ## Getting Blog Index and Token
 


### PR DESCRIPTION
GitHub assets generally need `./` as a suffix. This PR fixes the image.	