### PR TITLE
Support Underline

### DIFF
--- a/src/lib/notion/renderers.ts
+++ b/src/lib/notion/renderers.ts
@@ -10,7 +10,10 @@ function applyTags(tags = [], children, noPTag = false, key) {
 
     if (noPTag && tagName === 'p') tagName = React.Fragment
     if (tagName === 'c') tagName = 'code'
-
+    if (tagName === '_') {
+      tagName = 'span'
+      props.className = 'underline'
+    }
     if (tagName === 'a') {
       props.href = tag[1]
     }

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -115,6 +115,10 @@
   margin-left: 8px;
 }
 
+.post :global(.underline) {
+  border-bottom: 1px solid black;
+}
+
 .postPreview :global(.posted) {
   margin-bottom: 0.5em;
 }

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -116,7 +116,7 @@
 }
 
 .post :global(.underline) {
-  border-bottom: 1px solid black;
+  text-decoration: underline;
 }
 
 .postPreview :global(.posted) {


### PR DESCRIPTION
# Why

Error occurs when loading "Underline text".
The returned value tag name is "_" from the API.

<img width="830" alt="スクリーンショット 2020-06-28 23 59 54" src="https://user-images.githubusercontent.com/5053646/85951103-00579d00-b99c-11ea-8a3c-30467eed8cf9.png">

# How

- Add supporting renderer's Notion
- Add .underline in CSS
