### PR TITLE
fix: Blog link not showing pointer cursor

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -71,14 +71,14 @@ export default ({ posts = [], preview }) => {
           return (
             <div className={blogStyles.postPreview} key={post.Slug}>
               <h3>
-                <Link href="/blog/[slug]" as={getBlogLink(post.Slug)}>
-                  <div className={blogStyles.titleContainer}>
-                    {!post.Published && (
-                      <span className={blogStyles.draftBadge}>Draft</span>
-                    )}
+                <span className={blogStyles.titleContainer}>
+                  {!post.Published && (
+                    <span className={blogStyles.draftBadge}>Draft</span>
+                  )}
+                  <Link href="/blog/[slug]" as={getBlogLink(post.Slug)}>
                     <a>{post.Page}</a>
-                  </div>
-                </Link>
+                  </Link>
+                </span>
               </h3>
               {post.Authors.length > 0 && (
                 <div className="authors">By: {post.Authors.join(' ')}</div>


### PR DESCRIPTION
## What is this pr about? 👀

Fix cursor behavior when hovering Blog titles.

## Changes 🎁
- [x] Wrap `a` tag inside the `Link` component. As stated [here](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag)