### PR TITLE
fix: set pagination limit to 30 and query all pagniated results

### DIFF
--- a/src/lib/notion/getPageData.ts
+++ b/src/lib/notion/getPageData.ts
@@ -1,16 +1,23 @@
 import rpc, { values } from './rpc'
 
 export default async function getPageData(pageId: string) {
+  const maximumChunckNumer = 1000_0 // a reasonable size limit for the largest blog post (100MB), as one chunk is about 10KB
   try {
-    const data = await loadPageChunk({ pageId })
-    const blocks = values(data.recordMap.block)
+    var chunkNumber = 0
+    var data = await loadPageChunk({ pageId, chunkNumber })
+    var blocks = data.recordMap.block
 
-    if (blocks[0] && blocks[0].value.content) {
-      // remove table blocks
-      blocks.splice(0, 3)
+    while (data.cursor.stack.length != 0 && chunkNumber < maximumChunckNumer) {
+      chunkNumber = chunkNumber + 1
+      data = await loadPageChunk({ pageId, chunkNumber, cursor: data.cursor })
+      blocks = Object.assign(blocks, data.recordMap.block)
     }
-
-    return { blocks }
+    const blockArray = values(blocks)
+    if (blockArray[0] && blockArray[0].value.content) {
+      // remove table blocks
+      blockArray.splice(0, 3)
+    }
+    return { blocks: blockArray }
   } catch (err) {
     console.error(`Failed to load pageData for ${pageId}`, err)
     return { blocks: [] }
@@ -19,7 +26,7 @@ export default async function getPageData(pageId: string) {
 
 export function loadPageChunk({
   pageId,
-  limit = 100,
+  limit = 30,
   cursor = { stack: [] },
   chunkNumber = 0,
   verticalColumns = false,


### PR DESCRIPTION
Notion paginates the result from `loadPageChunk` API request. With
pagination, the results are divided into "chunks" of data contains
rougly 100 blocks (or less, can be specified in the `limit` attribute
of the request).

Currently, notion-blog only process the first "chunk" of the results,
when the page contains more than 100 blocks of data, the rest of them
is ignored.

In order to get the full result, we need examine the `cursor` object
from the response, if it contains a non-empty array of `stack`, we
should use it for the next `loadPageChunk` API request.

Additionally, set the `limit` to 30 as there is no need to fetch 100
blocks of data at one time.